### PR TITLE
Add dark mode toggle to side panel

### DIFF
--- a/extension/sidepanel.html
+++ b/extension/sidepanel.html
@@ -70,8 +70,16 @@
       <div class="section">
         <label data-tooltip="Shows a hand cursor when hovering over topic rows"><input type="checkbox" id="pointer-cursor"> Pointer cursor on topics</label>
       </div>
-
+      
       <div class="divider"></div>
+      <div class="section">
+  <label data-tooltip="Toggle dark theme for the extension and forum pages">
+    <input type="checkbox" id="dark-mode-toggle"> Dark mode
+  </label>
+</div>
+
+<div class="divider"></div>
+
 
       <div class="section">
         <div class="time-today" id="time-today" data-tooltip="Time spent on Bogleheads today">0 minutes today</div>

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -34,6 +34,7 @@
   var hideOldCheckbox = document.getElementById('hide-old');
   var maxAgeDaysInput = document.getElementById('max-age-days');
   var pointerCursorCheckbox = document.getElementById('pointer-cursor');
+  var darkModeCheckbox = document.getElementById('dark-mode-toggle');
   var timeTodayEl = document.getElementById('time-today');
   var timeTotalEl = document.getElementById('time-total');
   var sparklineEl = document.getElementById('sparkline');
@@ -191,7 +192,7 @@
   }
 
   // Load saved settings and apply to UI
-  chrome.storage.sync.get(['enableStriping', 'stripeColor', 'hideRead', 'readTopics', 'highlightHot', 'hotThreshold', 'hotColor', 'fontSize', 'hideOld', 'maxAgeDays', 'pointerCursor', 'enableWatchPosters', 'watchedPosters', 'watchColor'], function(result) {
+  chrome.storage.sync.get(['theme', 'enableStriping', 'stripeColor', 'hideRead', 'readTopics', 'highlightHot', 'hotThreshold', 'hotColor', 'fontSize', 'hideOld', 'maxAgeDays', 'pointerCursor', 'enableWatchPosters', 'watchedPosters', 'watchColor'], function(result) {
     var color = result.stripeColor || DEFAULT_COLOR;
     var hideRead = result.hideRead || false;
     var readTopics = result.readTopics || {};
@@ -203,7 +204,8 @@
     var hideOld = result.hideOld || false;
     var maxAgeDays = result.maxAgeDays || 30;
     var pointerCursor = result.pointerCursor || false;
-
+    var theme = result.theme || 'light';
+    darkModeCheckbox.checked = theme === 'dark';
     var enableStriping = result.enableStriping !== false;
     enableStripingCheckbox.checked = enableStriping;
     colorInput.value = color;
@@ -285,6 +287,11 @@
 
   pointerCursorCheckbox.onchange = function() {
     chrome.storage.sync.set({ pointerCursor: this.checked });
+  };
+  darkModeCheckbox.onchange = function() {
+  var theme = this.checked ? 'dark' : 'light';
+  chrome.storage.sync.set({ theme: theme });
+  applyTheme(theme);
   };
 
   enableWatchPostersCheckbox.onchange = function() {


### PR DESCRIPTION
Adds a dark mode toggle to the side panel using the existing theme logic.

- Exposes the already-implemented dark theme via a checkbox  
- Persists the user’s preference using `chrome.storage`  
- No new styling logic introduced
<img width="1911" height="851" alt="Screenshot 2026-02-03 122453" src="https://github.com/user-attachments/assets/5c7e2f6f-3b8b-4cef-bee3-355e6a08b167" />
